### PR TITLE
feat(start): natively show bunyan logs

### DIFF
--- a/src/Procfile
+++ b/src/Procfile
@@ -1,5 +1,5 @@
 web:    cross-env PORT=`expr $PORT + $WEB_PORT_OFFSET` react-scripts start --color
-node: cross-env PORT=`expr $PORT + $NODE_PORT_OFFSET` nodemon --config $root/nodemon.json --exec babel-node $src -- --config-file=$root/babel.config.js --no-babelrc
+node:   cross-env PORT=`expr $PORT + $NODE_PORT_OFFSET` nodemon --config $root/nodemon.json --exec babel-node $src -- --config-file=$root/babel.config.js --no-babelrc | bunyan -o short --color
 mongod: mkdir -p data/db && mongod --dbpath data/db --bind_ip 127.0.0.1 --port $MONGOD_PORT
 redis:  redis-server --port $REDIS_PORT
 

--- a/src/nodemon.json
+++ b/src/nodemon.json
@@ -5,7 +5,7 @@
   "ignore": [
     "**/*.spec.js",
     "**/*.test.js",
-    "**/*.web.js",
+    "**/*.web.*",
     "setupProxy.js",
     "setupTests.js"
   ]


### PR DESCRIPTION
it SEEMS to pass through normal console logs, so why not